### PR TITLE
UI polish: reactions, avatars, and post editing fixes

### DIFF
--- a/src/app/(main)/post/[id]/edit/page.tsx
+++ b/src/app/(main)/post/[id]/edit/page.tsx
@@ -64,7 +64,7 @@ export default function EditPostPage({ params }: EditPostPageProps) {
 
     updateMutation.mutate({
       id,
-      title: editorData.title || undefined,
+      title: editorData.title || null,
       content: editorData.content,
       liveUrl: editorData.liveUrl || undefined,
       projectIds: editorData.projects.map((p) => p.id),

--- a/src/app/(main)/post/[id]/page.tsx
+++ b/src/app/(main)/post/[id]/page.tsx
@@ -20,7 +20,7 @@ export default async function PostPage({ params }: PostPageProps) {
   }
 
   return (
-    <div className="mx-auto max-w-3xl space-y-8">
+    <div className="mx-auto max-w-3xl space-y-4">
       <ScrollToHash />
       <Suspense
         fallback={

--- a/src/components/reactions/ReactionButton.tsx
+++ b/src/components/reactions/ReactionButton.tsx
@@ -15,7 +15,7 @@ import {
   TooltipTrigger,
 } from "~/components/ui/tooltip";
 import { api } from "~/lib/trpc/client";
-import { Heart, Sparkles, ThumbsUp, SmilePlus, type LucideIcon } from "lucide-react";
+import { Heart, Sparkles, CircleCheck, SmilePlus, type LucideIcon } from "lucide-react";
 import { cn, pluralize } from "~/lib/utils";
 import { EmojiImage } from "~/components/settings/EmojiUpload";
 import { ReactionsDialog } from "./ReactionsDialog";
@@ -49,9 +49,9 @@ function isCustomEmoji(reaction: ReactionOption): reaction is CustomEmojiReactio
 }
 
 const DEFAULT_REACTIONS: DefaultReaction[] = [
-  { type: "like", icon: ThumbsUp, label: "Like" },
+  { type: "like", icon: Heart, label: "Like" },
   { type: "wow", icon: Sparkles, label: "Wow" },
-  { type: "cool", icon: Heart, label: "Cool" },
+  { type: "approve", icon: CircleCheck, label: "Approve" },
 ];
 
 export function ReactionButton({
@@ -131,7 +131,7 @@ export function ReactionButton({
   const { optimisticCount, reactionCounts } = useMemo(() => {
     // Start with reactions from other users
     const otherReactions = reactions.filter((r) => r.userId !== currentUserId);
-    
+
     // Add optimistic user reaction if present
     const allReactions =
       optimisticReaction && currentUserId
@@ -176,7 +176,7 @@ export function ReactionButton({
       // Fallback for unknown reaction types
       return <SmilePlus className={size === "sm" ? "h-3 w-3" : "h-5 w-5"} />;
     }
-    
+
     if (isCustomEmoji(reaction)) {
       return (
         <EmojiImage
@@ -186,7 +186,7 @@ export function ReactionButton({
         />
       );
     }
-    
+
     const Icon = reaction.icon;
     return <Icon className={size === "sm" ? "h-3 w-3" : "h-5 w-5"} />;
   };
@@ -205,7 +205,7 @@ export function ReactionButton({
     }
 
     const names = users.map((u) => u.userName);
-    
+
     if (names.length <= 3) {
       return { text: names.join(", "), hasMore: false, moreCount: 0 };
     }

--- a/src/components/reactions/ReactionsDialog.tsx
+++ b/src/components/reactions/ReactionsDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from "~/components/ui/dialog";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "~/components/ui/tabs";
 import { UserAvatar } from "~/components/ui/avatar";
-import { Heart, Sparkles, ThumbsUp, SmilePlus, type LucideIcon } from "lucide-react";
+import { Heart, Sparkles, CircleCheck, SmilePlus, type LucideIcon } from "lucide-react";
 import { EmojiImage } from "~/components/settings/EmojiUpload";
 import { cn, pluralize } from "~/lib/utils";
 
@@ -41,9 +41,9 @@ function isCustomEmoji(reaction: ReactionOption): reaction is CustomEmojiReactio
 }
 
 const DEFAULT_REACTIONS: DefaultReaction[] = [
-  { type: "like", icon: ThumbsUp, label: "Like" },
+  { type: "like", icon: Heart, label: "Like" },
   { type: "wow", icon: Sparkles, label: "Wow" },
-  { type: "cool", icon: Heart, label: "Cool" },
+  { type: "approve", icon: CircleCheck, label: "Approve" },
 ];
 
 export function ReactionsDialog({

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -26,7 +26,7 @@ const AvatarImage = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Image
     ref={ref}
-    className={cn("aspect-square h-full w-full", className)}
+    className={cn("aspect-square h-full w-full object-cover", className)}
     {...props}
   />
 ));

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -22,7 +22,7 @@ export const updateProfileSchema = z.object({
 
 // Post validators
 export const createPostSchema = z.object({
-  title: z.string().max(200).optional(),
+  title: z.string().max(200).optional().nullable(),
   content: z.any(), // Lexical editor state JSON
   liveUrl: z.string().url().optional().nullable(),
   hideFromHome: z.boolean().default(false),


### PR DESCRIPTION
## Summary

- **Reactions revamp**: Default reactions updated — Like now uses a Heart icon (was ThumbsUp), and Cool is replaced with Approve using a CircleCheck icon. Updated in both `ReactionButton` and `ReactionsDialog` to stay in sync.
- **Avatar fix**: Non-square avatar images were being stretched/squished to fill the circle. Added `object-cover` to `AvatarImage` so they crop-to-fill instead.
- **Post title clearing**: Post titles can now be explicitly set to `null` (was only `undefined`), allowing users to remove a title when editing. Updated the Zod validator and the edit page.
- **Post detail spacing**: Reduced vertical spacing on the post detail page from `space-y-8` to `space-y-4` for a tighter layout.

## Test plan

- [ ] Verify reaction icons render correctly (Heart for Like, Sparkles for Wow, CircleCheck for Approve)
- [ ] Open the reactions dialog and confirm the same icons/labels appear in the tab list
- [ ] Upload a non-square image as an avatar and confirm it displays without distortion
- [ ] Edit a post, clear the title, save, and confirm the title is removed
- [ ] Check post detail page spacing looks correct


Made with [Cursor](https://cursor.com)