### PR TITLE
Improve media uploads with progress tracking, polish, and draft restoration fix

### DIFF
--- a/src/app/(main)/compose/page.tsx
+++ b/src/app/(main)/compose/page.tsx
@@ -19,6 +19,8 @@ export default function ComposePage() {
   const searchParams = useSearchParams();
   const draftId = searchParams.get("draft");
 
+  // mountId changes on every mount AND every reappear (Next.js re-runs effects when page is shown)
+  const [mountId, setMountId] = useState(0);
   const [editorData, setEditorData] = useState<PostEditorData>({
     title: "",
     content: null,
@@ -30,35 +32,66 @@ export default function ComposePage() {
   const [isSaving, setIsSaving] = useState(false);
   const [lastSaved, setLastSaved] = useState<Date | null>(null);
   const [hasScrolled, setHasScrolled] = useState(false);
+  const [draftLoaded, setDraftLoaded] = useState(!draftId);
 
   const autosaveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
-  const isLoadedRef = useRef(false);
-  const isInitialRenderRef = useRef(true);
+  const pendingSaveRef = useRef<(() => void) | null>(null);
+  const suppressAutosaveRef = useRef(!!draftId);
   const currentDraftIdRef = useRef<string | null>(draftId);
-  // Stable key for Editor - only set once on mount to prevent remount after first save
-  const editorKeyRef = useRef<string>(draftId || "new");
 
-  // Load existing draft if draftId is provided
+  // This effect runs on mount AND on reappear (Next.js re-runs all effects when cached page becomes visible).
+  // It forces fresh state for the editor.
+  useEffect(() => {
+    setMountId((v) => v + 1);
+    setDraftLoaded(!draftId);
+    setLastSaved(null);
+    setIsSaving(false);
+    suppressAutosaveRef.current = !!draftId;
+    currentDraftIdRef.current = draftId;
+    setCurrentDraftId(draftId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Also reset when draftId changes (navigating between different drafts)
+  const prevDraftIdRef = useRef(draftId);
+  if (draftId !== prevDraftIdRef.current) {
+    prevDraftIdRef.current = draftId;
+    setMountId((v) => v + 1);
+    setDraftLoaded(!draftId);
+    setLastSaved(null);
+    setIsSaving(false);
+    suppressAutosaveRef.current = !!draftId;
+    currentDraftIdRef.current = draftId;
+    setCurrentDraftId(draftId);
+  }
+
+  // Load existing draft — always fetch fresh
   const { data: existingDraft, isLoading: isDraftLoading } =
     api.draft.getById.useQuery(
       { id: draftId! },
-      { enabled: !!draftId && !isLoadedRef.current }
+      {
+        enabled: !!draftId && !draftLoaded,
+        staleTime: 0,
+        gcTime: 0,
+      }
     );
 
-  // Initialize form with draft data
+  // Initialize form with draft data when it arrives
   useEffect(() => {
-    if (existingDraft && !isLoadedRef.current) {
+    if (existingDraft && !draftLoaded) {
       setEditorData({
         title: existingDraft.title || "",
         content: existingDraft.content as SerializedEditorState | null,
         liveUrl: existingDraft.liveUrl || "",
-        projects: [], // Drafts don't store projects currently
+        projects: [],
         hideFromHome: false,
       });
       setCurrentDraftId(existingDraft.id);
-      isLoadedRef.current = true;
+      currentDraftIdRef.current = existingDraft.id;
+      setDraftLoaded(true);
+      suppressAutosaveRef.current = true;
     }
-  }, [existingDraft]);
+  }, [existingDraft, draftLoaded]);
 
   const utils = api.useUtils();
 
@@ -69,8 +102,6 @@ export default function ComposePage() {
       setCurrentDraftId(draft.id);
       setLastSaved(new Date());
       setIsSaving(false);
-      // Mark as loaded so we don't show the loading screen
-      isLoadedRef.current = true;
       // Invalidate draft list so it appears in the menu immediately
       utils.draft.list.invalidate();
       // Update URL with draft ID if it's a new draft (without causing navigation)
@@ -101,16 +132,16 @@ export default function ComposePage() {
     },
   });
 
-  // Debounced autosave effect - watches state changes and saves after delay
+  // Debounced autosave effect
   useEffect(() => {
-    // Skip autosave on initial render
-    if (isInitialRenderRef.current) {
-      isInitialRenderRef.current = false;
+    // Skip autosave when we just loaded draft data
+    if (suppressAutosaveRef.current) {
+      suppressAutosaveRef.current = false;
       return;
     }
 
-    // Skip if still loading draft data
-    if (draftId && !isLoadedRef.current) {
+    // Skip if draft data hasn't loaded yet
+    if (!draftLoaded) {
       return;
     }
 
@@ -124,7 +155,8 @@ export default function ComposePage() {
       return;
     }
 
-    autosaveTimeoutRef.current = setTimeout(() => {
+    const doSave = () => {
+      pendingSaveRef.current = null;
       setIsSaving(true);
       saveDraftMutation.mutate({
         id: currentDraftIdRef.current || undefined,
@@ -133,16 +165,28 @@ export default function ComposePage() {
         liveUrl: editorData.liveUrl || null,
         projectIds: editorData.projects.map((p) => p.id),
       });
-    }, AUTOSAVE_DELAY);
+    };
 
-    // Cleanup timeout on unmount or when dependencies change
+    pendingSaveRef.current = doSave;
+    autosaveTimeoutRef.current = setTimeout(doSave, AUTOSAVE_DELAY);
+
     return () => {
       if (autosaveTimeoutRef.current) {
         clearTimeout(autosaveTimeoutRef.current);
       }
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [editorData, draftId]);
+  }, [editorData, draftLoaded]);
+
+  // Flush any pending save when the component unmounts/hides
+  useEffect(() => {
+    return () => {
+      if (autosaveTimeoutRef.current) {
+        clearTimeout(autosaveTimeoutRef.current);
+      }
+      pendingSaveRef.current?.();
+    };
+  }, []);
 
   const handleEditorChange = useCallback((data: PostEditorData) => {
     setEditorData(data);
@@ -177,14 +221,17 @@ export default function ComposePage() {
     }
   };
 
-  // Only show loading screen when loading an existing draft from URL (not after creating a new one)
-  if (isDraftLoading && draftId && !isLoadedRef.current) {
+  // Show loading screen while fetching draft data
+  if (!draftLoaded && isDraftLoading) {
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
         <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
       </div>
     );
   }
+
+  // Editor key includes mountId to force remount on every page show
+  const editorKey = `${draftId || "new"}-${mountId}`;
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-background">
@@ -257,7 +304,7 @@ export default function ComposePage() {
                 : undefined
             }
             onChange={handleEditorChange}
-            editorKey={editorKeyRef.current}
+            editorKey={editorKey}
           />
         </div>
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,16 +100,19 @@
   @apply pointer-events-none absolute left-4 top-4 select-none text-muted-foreground/50;
 }
 
-/* Selectable decorator nodes (images, attachments) */
+/* Selectable decorator nodes (images, attachments, upload placeholders) */
 .editor-image,
-.editor-attachment {
-  @apply relative cursor-pointer;
+.editor-attachment,
+.editor-upload-placeholder {
+  @apply relative block w-full cursor-pointer;
 }
 
 .editor-image:focus,
 .editor-attachment:focus,
+.editor-upload-placeholder:focus,
 .editor-image.selected,
-.editor-attachment.selected {
+.editor-attachment.selected,
+.editor-upload-placeholder.selected {
   @apply outline-2 outline-primary outline-offset-2 outline;
 }
 

--- a/src/components/editor/Editor.tsx
+++ b/src/components/editor/Editor.tsx
@@ -24,6 +24,7 @@ import { MentionNode } from "./nodes/MentionNode";
 import { EmojiNode } from "./nodes/EmojiNode";
 import { ImageNode } from "./nodes/ImageNode";
 import { AttachmentNode } from "./nodes/AttachmentNode";
+import { UploadPlaceholderNode } from "./nodes/UploadPlaceholderNode";
 import { MentionPlugin } from "./plugins/MentionPlugin";
 import { EmojiPlugin } from "./plugins/EmojiPlugin";
 import { SlashCommandPlugin } from "./plugins/SlashCommandPlugin";
@@ -148,6 +149,7 @@ export function Editor({
       EmojiNode,
       ImageNode,
       AttachmentNode,
+      UploadPlaceholderNode,
     ],
     editorState: initialContent ? JSON.stringify(initialContent) : undefined,
     editable,

--- a/src/components/editor/nodes/AttachmentNode.tsx
+++ b/src/components/editor/nodes/AttachmentNode.tsx
@@ -66,7 +66,15 @@ function AttachmentComponent({
   const [editor] = useLexicalComposerContext();
   const [isEditable, setIsEditable] = useState(() => editor.isEditable());
   const [displayUrl, setDisplayUrl] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const isMedia = attachmentType === "IMAGE" || attachmentType === "VIDEO";
+  const requiresSigningInit = needsUrlSigning(url);
+  const [isLoading, setIsLoading] = useState(() => {
+    // Skip loading state if we have a thumbnail to show or URL doesn't need signing
+    if (thumbnailUrl) return false;
+    if (!isMedia) return false;
+    if (!requiresSigningInit) return false;
+    return true;
+  });
   const [error, setError] = useState<string | null>(null);
   const [fallbackLightboxOpen, setFallbackLightboxOpen] = useState(false);
 
@@ -96,8 +104,7 @@ function AttachmentComponent({
   };
 
   const storageKey = extractStorageKey(url);
-  const requiresSigning = needsUrlSigning(url);
-  const isMedia = attachmentType === "IMAGE" || attachmentType === "VIDEO";
+  const requiresSigning = requiresSigningInit;
   const { data: signedUrlData, isLoading: isLoadingUrl, error: urlError } = api.upload.getDownloadUrl.useQuery(
     { key: storageKey! },
     {
@@ -174,10 +181,15 @@ function AttachmentComponent({
     </button>
   );
 
+  const loadingAspectStyle = width && height
+    ? { aspectRatio: `${width / height}` }
+    : undefined;
+  const loadingAspectClass = !width || !height ? "aspect-video" : "";
+
   if (attachmentType === "IMAGE") {
     if (isLoading) {
       return (
-        <div className="my-4 flex h-48 items-center justify-center rounded-lg bg-muted">
+        <div className={`my-4 flex w-full items-center justify-center rounded-lg bg-muted ${loadingAspectClass}`} style={loadingAspectStyle}>
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       );
@@ -185,20 +197,20 @@ function AttachmentComponent({
 
     return (
       <>
-        <div className="group relative my-4 inline-block">
+        <div className="group relative my-4 w-full">
           {isEditable && <DeleteButton />}
           <button
             type="button"
             onClick={handleMediaClick}
-            className="block cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-lg"
+            className="block w-full cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-lg"
           >
-            <div className="inline-block rounded-lg bg-muted/50">
+            <div className="w-full rounded-lg bg-muted/50">
               <img
                 src={displayUrl || url}
                 alt={filename}
                 width={width}
                 height={height}
-                className="max-w-full rounded-lg"
+                className="w-full rounded-lg"
                 loading="lazy"
                 onError={(e) => {
                   // If image fails to load, show error state
@@ -226,7 +238,7 @@ function AttachmentComponent({
   if (attachmentType === "VIDEO") {
     if (isLoading) {
       return (
-        <div className="my-4 flex h-48 items-center justify-center rounded-lg bg-muted">
+        <div className={`my-4 flex w-full items-center justify-center rounded-lg bg-muted ${loadingAspectClass}`} style={loadingAspectStyle}>
           <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
         </div>
       );
@@ -234,25 +246,25 @@ function AttachmentComponent({
 
     return (
       <>
-        <div className="group relative my-4 inline-block">
+        <div className="group relative my-4 w-full">
           {isEditable && <DeleteButton />}
           <button
             type="button"
             onClick={handleMediaClick}
-            className="block cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-lg"
+            className="block w-full cursor-zoom-in focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded-lg"
           >
-            <div className="inline-block rounded-lg bg-muted/50 relative">
+            <div className="w-full rounded-lg bg-muted/50 relative">
               {thumbnailUrl ? (
                 <img
                   src={thumbnailUrl}
                   alt={filename}
-                  className="max-w-full rounded-lg"
+                  className="w-full rounded-lg"
                   loading="lazy"
                 />
               ) : (
                 <video
                   src={displayUrl || url}
-                  className="max-w-full rounded-lg pointer-events-none"
+                  className="w-full rounded-lg pointer-events-none"
                   muted
                   playsInline
                   preload="metadata"

--- a/src/components/editor/nodes/UploadPlaceholderNode.tsx
+++ b/src/components/editor/nodes/UploadPlaceholderNode.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import * as React from "react";
+import {
+  type EditorConfig,
+  type LexicalNode,
+  type NodeKey,
+  type SerializedLexicalNode,
+  type Spread,
+  DecoratorNode,
+  $getNodeByKey,
+  $createParagraphNode,
+} from "lexical";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import { useEffect, useRef, useState } from "react";
+import { FileIcon, ImageIcon, Film, Loader2, X } from "lucide-react";
+import { useUpload } from "~/lib/hooks/use-upload";
+import { getPendingUpload, removePendingUpload, cancelPendingUpload } from "~/lib/upload-store";
+import { $createAttachmentNode, type AttachmentType } from "./AttachmentNode";
+
+export type SerializedUploadPlaceholderNode = Spread<
+  {
+    uploadId: string;
+    filename: string;
+    fileSize: number;
+    mimeType: string;
+  },
+  SerializedLexicalNode
+>;
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getFileTypeIcon(mimeType: string) {
+  if (mimeType.startsWith("image/")) return <ImageIcon className="h-5 w-5 text-muted-foreground" />;
+  if (mimeType.startsWith("video/")) return <Film className="h-5 w-5 text-muted-foreground" />;
+  return <FileIcon className="h-5 w-5 text-muted-foreground" />;
+}
+
+function UploadPlaceholderComponent({
+  uploadId,
+  filename,
+  fileSize,
+  mimeType,
+  nodeKey,
+}: {
+  uploadId: string;
+  filename: string;
+  fileSize: number;
+  mimeType: string;
+  nodeKey: NodeKey;
+}) {
+  const [editor] = useLexicalComposerContext();
+  const [progress, setProgress] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const uploadStartedRef = useRef(false);
+
+  const { uploadFile } = useUpload();
+
+  useEffect(() => {
+    // Only start upload once
+    if (uploadStartedRef.current) return;
+    uploadStartedRef.current = true;
+
+    const entry = getPendingUpload(uploadId);
+    if (!entry) {
+      setError("Upload data not found");
+      return;
+    }
+
+    const { file, abortController } = entry;
+
+    const doUpload = async () => {
+      try {
+        const { url } = await uploadFile(file, {
+          onProgress: (p) => setProgress(p),
+          signal: abortController.signal,
+        });
+
+        // Determine attachment type
+        let attachmentType: AttachmentType = "FILE";
+        if (file.type.startsWith("image/")) {
+          attachmentType = "IMAGE";
+        } else if (file.type.startsWith("video/")) {
+          attachmentType = "VIDEO";
+        }
+
+        // Replace this placeholder node with the real AttachmentNode
+        editor.update(() => {
+          const node = $getNodeByKey(nodeKey);
+          if (node) {
+            const attachmentNode = $createAttachmentNode({
+              attachmentType,
+              url,
+              filename: file.name,
+              mimeType: file.type,
+              size: file.size,
+            });
+            node.replace(attachmentNode);
+          }
+        });
+
+        removePendingUpload(uploadId);
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          // Upload was cancelled - remove the node
+          editor.update(() => {
+            const node = $getNodeByKey(nodeKey);
+            if (node) {
+              node.remove();
+            }
+          });
+          return;
+        }
+
+        console.error("Upload failed:", err);
+        setError(err instanceof Error ? err.message : "Upload failed");
+        removePendingUpload(uploadId);
+      }
+    };
+
+    doUpload();
+  }, [uploadId, editor, nodeKey, uploadFile]);
+
+  const handleCancel = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    cancelPendingUpload(uploadId);
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if (node) {
+        node.remove();
+      }
+    });
+  };
+
+  const handleRetry = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    // On error, just remove the node - user can re-upload
+    editor.update(() => {
+      const node = $getNodeByKey(nodeKey);
+      if (node) {
+        node.remove();
+      }
+    });
+  };
+
+  const isMedia = mimeType.startsWith("image/") || mimeType.startsWith("video/");
+
+  if (error) {
+    return (
+      <div className="my-4 rounded-lg border border-destructive/50 bg-destructive/5 p-4">
+        <div className="flex items-center gap-3">
+          {getFileTypeIcon(mimeType)}
+          <div className="flex-1 min-w-0">
+            <p className="truncate text-sm font-medium">{filename}</p>
+            <p className="text-xs text-destructive">{error}</p>
+          </div>
+          <button
+            type="button"
+            onClick={handleRetry}
+            className="shrink-0 rounded-md px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={`my-4 rounded-lg border border-border bg-muted/30 overflow-hidden ${
+        isMedia ? "aspect-video max-h-64" : ""
+      }`}
+    >
+      <div className={`flex flex-col justify-center p-4 ${isMedia ? "h-full" : ""}`}>
+        <div className="flex items-center gap-3">
+          <div className="shrink-0">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="truncate text-sm font-medium text-foreground">{filename}</p>
+            <p className="text-xs text-muted-foreground">
+              {formatFileSize(fileSize)} · Uploading{progress > 0 ? ` · ${progress}%` : "..."}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+            aria-label="Cancel upload"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        {/* Progress bar */}
+        <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
+            style={{ width: `${Math.max(progress, 2)}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export class UploadPlaceholderNode extends DecoratorNode<React.ReactElement> {
+  __uploadId: string;
+  __filename: string;
+  __fileSize: number;
+  __mimeType: string;
+
+  static getType(): string {
+    return "upload-placeholder";
+  }
+
+  static clone(node: UploadPlaceholderNode): UploadPlaceholderNode {
+    return new UploadPlaceholderNode(
+      node.__uploadId,
+      node.__filename,
+      node.__fileSize,
+      node.__mimeType,
+      node.__key
+    );
+  }
+
+  constructor(
+    uploadId: string,
+    filename: string,
+    fileSize: number,
+    mimeType: string,
+    key?: NodeKey
+  ) {
+    super(key);
+    this.__uploadId = uploadId;
+    this.__filename = filename;
+    this.__fileSize = fileSize;
+    this.__mimeType = mimeType;
+  }
+
+  createDOM(_config: EditorConfig): HTMLElement {
+    const div = document.createElement("div");
+    div.className = "editor-upload-placeholder";
+    return div;
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  // If this node ends up in serialized state (e.g. page reload mid-upload),
+  // importJSON will recreate it but the upload data will be gone.
+  // The component handles this gracefully by showing an error.
+  static importJSON(serializedNode: SerializedUploadPlaceholderNode): UploadPlaceholderNode {
+    return new UploadPlaceholderNode(
+      serializedNode.uploadId,
+      serializedNode.filename,
+      serializedNode.fileSize,
+      serializedNode.mimeType
+    );
+  }
+
+  exportJSON(): SerializedUploadPlaceholderNode {
+    return {
+      type: "upload-placeholder",
+      version: 1,
+      uploadId: this.__uploadId,
+      filename: this.__filename,
+      fileSize: this.__fileSize,
+      mimeType: this.__mimeType,
+    };
+  }
+
+  decorate(): React.ReactElement {
+    return (
+      <UploadPlaceholderComponent
+        uploadId={this.__uploadId}
+        filename={this.__filename}
+        fileSize={this.__fileSize}
+        mimeType={this.__mimeType}
+        nodeKey={this.__key}
+      />
+    );
+  }
+
+  isInline(): boolean {
+    return false;
+  }
+
+  isKeyboardSelectable(): boolean {
+    return true;
+  }
+}
+
+export function $createUploadPlaceholderNode({
+  uploadId,
+  filename,
+  fileSize,
+  mimeType,
+}: {
+  uploadId: string;
+  filename: string;
+  fileSize: number;
+  mimeType: string;
+}): UploadPlaceholderNode {
+  return new UploadPlaceholderNode(uploadId, filename, fileSize, mimeType);
+}
+
+export function $isUploadPlaceholderNode(
+  node: LexicalNode | null | undefined
+): node is UploadPlaceholderNode {
+  return node instanceof UploadPlaceholderNode;
+}

--- a/src/components/editor/nodes/UploadPlaceholderNode.tsx
+++ b/src/components/editor/nodes/UploadPlaceholderNode.tsx
@@ -13,7 +13,7 @@ import {
 } from "lexical";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { useEffect, useRef, useState } from "react";
-import { FileIcon, ImageIcon, Film, Loader2, X } from "lucide-react";
+import { FileIcon, ImageIcon, Film, X } from "lucide-react";
 import { useUpload } from "~/lib/hooks/use-upload";
 import { getPendingUpload, removePendingUpload, cancelPendingUpload } from "~/lib/upload-store";
 import { $createAttachmentNode, type AttachmentType } from "./AttachmentNode";
@@ -56,9 +56,45 @@ function UploadPlaceholderComponent({
   const [editor] = useLexicalComposerContext();
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
+  const [aspectRatio, setAspectRatio] = useState<number | null>(null);
+  const mediaDimensionsRef = useRef<{ width: number; height: number } | null>(null);
   const uploadStartedRef = useRef(false);
 
   const { uploadFile } = useUpload();
+
+  // Read media dimensions to match aspect ratio
+  useEffect(() => {
+    const entry = getPendingUpload(uploadId);
+    if (!entry) return;
+    const { file } = entry;
+
+    if (file.type.startsWith("image/")) {
+      const img = new Image();
+      const objectUrl = URL.createObjectURL(file);
+      img.onload = () => {
+        if (img.naturalWidth && img.naturalHeight) {
+          mediaDimensionsRef.current = { width: img.naturalWidth, height: img.naturalHeight };
+          setAspectRatio(img.naturalWidth / img.naturalHeight);
+        }
+        URL.revokeObjectURL(objectUrl);
+      };
+      img.onerror = () => URL.revokeObjectURL(objectUrl);
+      img.src = objectUrl;
+    } else if (file.type.startsWith("video/")) {
+      const video = document.createElement("video");
+      video.preload = "metadata";
+      const objectUrl = URL.createObjectURL(file);
+      video.onloadedmetadata = () => {
+        if (video.videoWidth && video.videoHeight) {
+          mediaDimensionsRef.current = { width: video.videoWidth, height: video.videoHeight };
+          setAspectRatio(video.videoWidth / video.videoHeight);
+        }
+        URL.revokeObjectURL(objectUrl);
+      };
+      video.onerror = () => URL.revokeObjectURL(objectUrl);
+      video.src = objectUrl;
+    }
+  }, [uploadId]);
 
   useEffect(() => {
     // Only start upload once
@@ -73,12 +109,65 @@ function UploadPlaceholderComponent({
 
     const { file, abortController } = entry;
 
+    const captureVideoThumbnail = (file: File): Promise<string | undefined> => {
+      return new Promise((resolve) => {
+        try {
+          const video = document.createElement("video");
+          video.muted = true;
+          video.playsInline = true;
+          video.preload = "auto";
+          const objectUrl = URL.createObjectURL(file);
+          video.src = objectUrl;
+
+          video.addEventListener("loadeddata", () => {
+            // Seek to first frame
+            video.currentTime = 0.1;
+          });
+
+          video.addEventListener("seeked", () => {
+            try {
+              const canvas = document.createElement("canvas");
+              canvas.width = video.videoWidth;
+              canvas.height = video.videoHeight;
+              const ctx = canvas.getContext("2d");
+              if (ctx) {
+                ctx.drawImage(video, 0, 0);
+                const dataUrl = canvas.toDataURL("image/jpeg", 0.8);
+                URL.revokeObjectURL(objectUrl);
+                resolve(dataUrl);
+              } else {
+                URL.revokeObjectURL(objectUrl);
+                resolve(undefined);
+              }
+            } catch {
+              URL.revokeObjectURL(objectUrl);
+              resolve(undefined);
+            }
+          });
+
+          video.addEventListener("error", () => {
+            URL.revokeObjectURL(objectUrl);
+            resolve(undefined);
+          });
+        } catch {
+          resolve(undefined);
+        }
+      });
+    };
+
     const doUpload = async () => {
       try {
+        // Start thumbnail capture in parallel with upload for videos
+        const thumbnailPromise = file.type.startsWith("video/")
+          ? captureVideoThumbnail(file)
+          : Promise.resolve(undefined);
+
         const { url } = await uploadFile(file, {
           onProgress: (p) => setProgress(p),
           signal: abortController.signal,
         });
+
+        const thumbnailUrl = await thumbnailPromise;
 
         // Determine attachment type
         let attachmentType: AttachmentType = "FILE";
@@ -98,6 +187,9 @@ function UploadPlaceholderComponent({
               filename: file.name,
               mimeType: file.type,
               size: file.size,
+              thumbnailUrl,
+              width: mediaDimensionsRef.current?.width,
+              height: mediaDimensionsRef.current?.height,
             });
             node.replace(attachmentNode);
           }
@@ -151,14 +243,23 @@ function UploadPlaceholderComponent({
 
   const isMedia = mimeType.startsWith("image/") || mimeType.startsWith("video/");
 
+  const progressBar = (
+    <div className="h-1.5 w-24 overflow-hidden rounded-full bg-foreground/10">
+      <div
+        className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
+        style={{ width: `${Math.max(progress, 2)}%` }}
+      />
+    </div>
+  );
+
   if (error) {
     return (
       <div className="my-4 rounded-lg border border-destructive/50 bg-destructive/5 p-4">
         <div className="flex items-center gap-3">
           {getFileTypeIcon(mimeType)}
           <div className="flex-1 min-w-0">
-            <p className="truncate text-sm font-medium">{filename}</p>
-            <p className="text-xs text-destructive">{error}</p>
+            <p className="truncate font-medium">{filename}</p>
+            <p className="text-sm text-destructive">{error}</p>
           </div>
           <button
             type="button"
@@ -172,39 +273,59 @@ function UploadPlaceholderComponent({
     );
   }
 
-  return (
-    <div
-      className={`my-4 rounded-lg border border-border bg-muted/30 overflow-hidden ${
-        isMedia ? "aspect-video max-h-64" : ""
-      }`}
-    >
-      <div className={`flex flex-col justify-center p-4 ${isMedia ? "h-full" : ""}`}>
-        <div className="flex items-center gap-3">
-          <div className="shrink-0">
-            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+  // File upload placeholder — matches finished file attachment layout
+  if (!isMedia) {
+    return (
+      <div className="group relative my-4">
+        <button
+          type="button"
+          onClick={handleCancel}
+          className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity hover:bg-black/80 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-white"
+          aria-label="Cancel upload"
+        >
+          <X className="h-4 w-4" />
+        </button>
+        <div className="flex items-center gap-3 rounded-lg border border-border bg-card p-4 pr-7">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted">
+            <FileIcon className="h-5 w-5 text-muted-foreground" />
           </div>
-          <div className="flex-1 min-w-0">
-            <p className="truncate text-sm font-medium text-foreground">{filename}</p>
-            <p className="text-xs text-muted-foreground">
+          <div className="flex-1 overflow-hidden">
+            <p className="truncate font-medium">{filename}</p>
+            <p className="text-sm text-muted-foreground">
               {formatFileSize(fileSize)} · Uploading{progress > 0 ? ` · ${progress}%` : "..."}
             </p>
           </div>
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="shrink-0 flex h-7 w-7 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-            aria-label="Cancel upload"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          {progressBar}
         </div>
-        {/* Progress bar */}
-        <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-muted">
-          <div
-            className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
-            style={{ width: `${Math.max(progress, 2)}%` }}
-          />
-        </div>
+      </div>
+    );
+  }
+
+  // Media upload placeholder — centered vertical layout with aspect ratio
+  return (
+    <div
+      className="group relative my-4 w-full rounded-lg bg-muted overflow-hidden"
+      style={aspectRatio ? { aspectRatio: `${aspectRatio}` } : undefined}
+    >
+      <button
+        type="button"
+        onClick={handleCancel}
+        className="absolute right-2 top-2 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-black/60 text-white opacity-0 transition-opacity hover:bg-black/80 group-hover:opacity-100 focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-white"
+        aria-label="Cancel upload"
+      >
+        <X className="h-4 w-4" />
+      </button>
+      <div className={`flex w-full flex-col items-center justify-center ${aspectRatio ? "absolute inset-0" : "p-8"}`}>
+        {mimeType.startsWith("video/") ? (
+          <Film className="h-6 w-6 text-muted-foreground" />
+        ) : (
+          <ImageIcon className="h-6 w-6 text-muted-foreground" />
+        )}
+        <p className="mt-3 truncate text-sm font-medium text-foreground">{filename}</p>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {formatFileSize(fileSize)} · Uploading{progress > 0 ? ` · ${progress}%` : "..."}
+        </p>
+        <div className="mt-3">{progressBar}</div>
       </div>
     </div>
   );

--- a/src/components/editor/plugins/DragDropPlugin.tsx
+++ b/src/components/editor/plugins/DragDropPlugin.tsx
@@ -10,52 +10,40 @@ import {
   DROP_COMMAND,
   DRAGOVER_COMMAND,
 } from "lexical";
-import { $createAttachmentNode, type AttachmentType } from "../nodes/AttachmentNode";
-import { useUpload } from "~/lib/hooks/use-upload";
+import { $createUploadPlaceholderNode } from "../nodes/UploadPlaceholderNode";
+import { generateUploadId, registerPendingUpload } from "~/lib/upload-store";
 
 export function DragDropPlugin() {
   const [editor] = useLexicalComposerContext();
-  const { uploadFile } = useUpload();
 
   const handleDrop = useCallback(
-    async (event: DragEvent) => {
+    (event: DragEvent) => {
       const files = event.dataTransfer?.files;
       if (!files || files.length === 0) return false;
 
       event.preventDefault();
 
       for (const file of Array.from(files)) {
-        try {
-          const { url } = await uploadFile(file);
+        const uploadId = generateUploadId();
+        registerPendingUpload(uploadId, file);
 
-          let attachmentType: AttachmentType = "FILE";
-          if (file.type.startsWith("image/")) {
-            attachmentType = "IMAGE";
-          } else if (file.type.startsWith("video/")) {
-            attachmentType = "VIDEO";
+        editor.update(() => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            const placeholderNode = $createUploadPlaceholderNode({
+              uploadId,
+              filename: file.name,
+              fileSize: file.size,
+              mimeType: file.type,
+            });
+            selection.insertNodes([placeholderNode, $createParagraphNode()]);
           }
-
-          editor.update(() => {
-            const selection = $getSelection();
-            if ($isRangeSelection(selection)) {
-              const attachmentNode = $createAttachmentNode({
-                attachmentType,
-                url,
-                filename: file.name,
-                mimeType: file.type,
-                size: file.size,
-              });
-              selection.insertNodes([attachmentNode, $createParagraphNode()]);
-            }
-          });
-        } catch (error) {
-          console.error("Upload failed:", error);
-        }
+        });
       }
 
       return true;
     },
-    [editor, uploadFile]
+    [editor]
   );
 
   useEffect(() => {

--- a/src/components/editor/plugins/FloatingAddButtonPlugin.tsx
+++ b/src/components/editor/plugins/FloatingAddButtonPlugin.tsx
@@ -88,6 +88,35 @@ export function FloatingAddButtonPlugin({ anchorElem }: FloatingAddButtonPluginP
     });
   }, [editor, updatePosition]);
 
+  // Also reposition when DOM layout changes (e.g. upload placeholder aspect ratio loads)
+  useEffect(() => {
+    const observer = new ResizeObserver(() => {
+      updatePosition();
+    });
+    observer.observe(anchorElem);
+    // Observe all decorator nodes (placeholders, attachments) for size changes
+    const decorators = anchorElem.querySelectorAll(
+      ".editor-upload-placeholder, .editor-attachment"
+    );
+    decorators.forEach((el) => observer.observe(el));
+
+    // Also watch for new decorator nodes being added
+    const mutationObserver = new MutationObserver(() => {
+      // Re-observe any new decorator nodes
+      const newDecorators = anchorElem.querySelectorAll(
+        ".editor-upload-placeholder, .editor-attachment"
+      );
+      newDecorators.forEach((el) => observer.observe(el));
+      updatePosition();
+    });
+    mutationObserver.observe(anchorElem, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      mutationObserver.disconnect();
+    };
+  }, [anchorElem, updatePosition]);
+
   // Close menu when clicking outside
   useEffect(() => {
     if (!isMenuOpen) return;

--- a/src/components/editor/plugins/FloatingAddButtonPlugin.tsx
+++ b/src/components/editor/plugins/FloatingAddButtonPlugin.tsx
@@ -6,11 +6,7 @@ import {
   $getSelection,
   $isRangeSelection,
   $createParagraphNode,
-  $getNodeByKey,
   $isParagraphNode,
-  COMMAND_PRIORITY_LOW,
-  KEY_ARROW_DOWN_COMMAND,
-  KEY_ARROW_UP_COMMAND,
 } from "lexical";
 import { createPortal } from "react-dom";
 import {
@@ -22,13 +18,12 @@ import {
   List,
   ListOrdered,
   Quote,
-  X,
 } from "lucide-react";
-import { $createAttachmentNode, type AttachmentType } from "../nodes/AttachmentNode";
 import { $setBlocksType } from "@lexical/selection";
 import { $createHeadingNode, $createQuoteNode } from "@lexical/rich-text";
 import { INSERT_ORDERED_LIST_COMMAND, INSERT_UNORDERED_LIST_COMMAND } from "@lexical/list";
-import { useUpload } from "~/lib/hooks/use-upload";
+import { $createUploadPlaceholderNode } from "../nodes/UploadPlaceholderNode";
+import { generateUploadId, registerPendingUpload } from "~/lib/upload-store";
 import { cn } from "~/lib/utils";
 
 interface FloatingAddButtonPluginProps {
@@ -43,7 +38,6 @@ export function FloatingAddButtonPlugin({ anchorElem }: FloatingAddButtonPluginP
   const [isEmpty, setIsEmpty] = useState(false);
   const buttonRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { uploadFile } = useUpload();
 
   const updatePosition = useCallback(() => {
     editor.getEditorState().read(() => {
@@ -108,39 +102,26 @@ export function FloatingAddButtonPlugin({ anchorElem }: FloatingAddButtonPluginP
     return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [isMenuOpen]);
 
-  const handleFileUpload = useCallback(
-    async (file: File) => {
+  const insertUploadPlaceholder = useCallback(
+    (file: File) => {
       setIsMenuOpen(false);
-      try {
-        const { url } = await uploadFile(file);
+      const uploadId = generateUploadId();
+      registerPendingUpload(uploadId, file);
 
-        let attachmentType: AttachmentType = "FILE";
-        if (file.type.startsWith("image/")) {
-          attachmentType = "IMAGE";
-        } else if (file.type.startsWith("video/")) {
-          attachmentType = "VIDEO";
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          const placeholderNode = $createUploadPlaceholderNode({
+            uploadId,
+            filename: file.name,
+            fileSize: file.size,
+            mimeType: file.type,
+          });
+          selection.insertNodes([placeholderNode, $createParagraphNode()]);
         }
-
-        editor.update(() => {
-          const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            const attachmentNode = $createAttachmentNode({
-              attachmentType,
-              url,
-              filename: file.name,
-              mimeType: file.type,
-              size: file.size,
-            });
-            selection.insertNodes([attachmentNode, $createParagraphNode()]);
-          }
-        });
-      } catch (error) {
-        console.error("Upload failed:", error);
-        const message = error instanceof Error ? error.message : "Unknown error";
-        alert(`Upload failed: ${message}`);
-      }
+      });
     },
-    [editor, uploadFile]
+    [editor]
   );
 
   const triggerFileInput = (accept: string) => {
@@ -191,7 +172,7 @@ export function FloatingAddButtonPlugin({ anchorElem }: FloatingAddButtonPluginP
         onChange={(e) => {
           const file = e.target.files?.[0];
           if (file) {
-            handleFileUpload(file);
+            insertUploadPlaceholder(file);
           }
           e.target.value = "";
         }}
@@ -215,15 +196,15 @@ export function FloatingAddButtonPlugin({ anchorElem }: FloatingAddButtonPluginP
             Add blocks
           </p>
           <button
-            onClick={() => triggerFileInput("image/*")}
+            onClick={() => triggerFileInput("image/*,video/*")}
             className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted"
           >
             <div className="flex h-7 w-7 items-center justify-center rounded-md border bg-background">
               <ImagePlus className="h-4 w-4" />
             </div>
             <div className="text-left">
-              <p className="font-medium">Image</p>
-              <p className="text-xs text-muted-foreground">Upload an image</p>
+              <p className="font-medium">Media</p>
+              <p className="text-xs text-muted-foreground">Upload images or videos</p>
             </div>
           </button>
           <button

--- a/src/components/editor/plugins/PasteFilePlugin.tsx
+++ b/src/components/editor/plugins/PasteFilePlugin.tsx
@@ -9,49 +9,37 @@ import {
   COMMAND_PRIORITY_HIGH,
   PASTE_COMMAND,
 } from "lexical";
-import { $createAttachmentNode, type AttachmentType } from "../nodes/AttachmentNode";
-import { useUpload } from "~/lib/hooks/use-upload";
+import { $createUploadPlaceholderNode } from "../nodes/UploadPlaceholderNode";
+import { generateUploadId, registerPendingUpload } from "~/lib/upload-store";
 
 /**
  * Plugin that handles pasting files (images, videos, other files) from clipboard.
- * When a file is pasted, it's uploaded and inserted as an attachment node.
+ * When a file is pasted, a placeholder is immediately inserted showing upload progress.
  */
 export function PasteFilePlugin() {
   const [editor] = useLexicalComposerContext();
-  const { uploadFile } = useUpload();
 
-  const uploadAndInsertFiles = useCallback(
-    async (files: File[]) => {
+  const insertPlaceholders = useCallback(
+    (files: File[]) => {
       for (const file of files) {
-        try {
-          const { url } = await uploadFile(file);
+        const uploadId = generateUploadId();
+        registerPendingUpload(uploadId, file);
 
-          let attachmentType: AttachmentType = "FILE";
-          if (file.type.startsWith("image/")) {
-            attachmentType = "IMAGE";
-          } else if (file.type.startsWith("video/")) {
-            attachmentType = "VIDEO";
+        editor.update(() => {
+          const selection = $getSelection();
+          if ($isRangeSelection(selection)) {
+            const placeholderNode = $createUploadPlaceholderNode({
+              uploadId,
+              filename: file.name,
+              fileSize: file.size,
+              mimeType: file.type,
+            });
+            selection.insertNodes([placeholderNode, $createParagraphNode()]);
           }
-
-          editor.update(() => {
-            const selection = $getSelection();
-            if ($isRangeSelection(selection)) {
-              const attachmentNode = $createAttachmentNode({
-                attachmentType,
-                url,
-                filename: file.name,
-                mimeType: file.type,
-                size: file.size,
-              });
-              selection.insertNodes([attachmentNode, $createParagraphNode()]);
-            }
-          });
-        } catch (error) {
-          console.error("Paste upload failed:", error);
-        }
+        });
       }
     },
-    [editor, uploadFile]
+    [editor]
   );
 
   useEffect(() => {
@@ -71,13 +59,13 @@ export function PasteFilePlugin() {
         const actualFiles = Array.from(files).filter((file) => file.size > 0);
         if (actualFiles.length === 0) return false;
 
-        // Handle the upload asynchronously
-        uploadAndInsertFiles(actualFiles);
+        // Insert placeholders immediately
+        insertPlaceholders(actualFiles);
         return true;
       },
       COMMAND_PRIORITY_HIGH
     );
-  }, [editor, uploadAndInsertFiles]);
+  }, [editor, insertPlaceholders]);
 
   return null;
 }

--- a/src/components/editor/plugins/SlashCommandPlugin.tsx
+++ b/src/components/editor/plugins/SlashCommandPlugin.tsx
@@ -29,8 +29,8 @@ import {
   ImagePlus,
   FileUp,
 } from "lucide-react";
-import { $createAttachmentNode, type AttachmentType } from "../nodes/AttachmentNode";
-import { useUpload } from "~/lib/hooks/use-upload";
+import { $createUploadPlaceholderNode } from "../nodes/UploadPlaceholderNode";
+import { generateUploadId, registerPendingUpload } from "~/lib/upload-store";
 import { cn } from "~/lib/utils";
 
 interface CommandOption {
@@ -43,10 +43,10 @@ interface CommandOption {
 
 const COMMANDS: CommandOption[] = [
   {
-    name: "Image",
-    command: "image",
+    name: "Media",
+    command: "media",
     icon: <ImagePlus className="h-4 w-4" />,
-    description: "Upload an image",
+    description: "Upload images or videos",
     section: "media",
   },
   {
@@ -106,7 +106,6 @@ export function SlashCommandPlugin({ anchorElem }: SlashCommandPluginProps) {
   const [position, setPosition] = useState({ top: 0, left: 0 });
   const menuRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
-  const { uploadFile } = useUpload();
   const pendingCommandRef = useRef<string | null>(null);
 
   const filteredCommands = useMemo(() => {
@@ -116,7 +115,10 @@ export function SlashCommandPlugin({ anchorElem }: SlashCommandPluginProps) {
       (cmd) =>
         cmd.name.toLowerCase().includes(lowerQuery) ||
         cmd.description?.toLowerCase().includes(lowerQuery) ||
-        cmd.command.toLowerCase().includes(lowerQuery)
+        cmd.command.toLowerCase().includes(lowerQuery) ||
+        // Allow "image" to match "media" for discoverability
+        (cmd.command === "media" && "image".includes(lowerQuery)) ||
+        (cmd.command === "media" && "video".includes(lowerQuery))
     );
   }, [query]);
 
@@ -125,37 +127,25 @@ export function SlashCommandPlugin({ anchorElem }: SlashCommandPluginProps) {
     setSelectedIndex(0);
   }, [filteredCommands.length]);
 
-  const handleFileUpload = useCallback(
-    async (file: File) => {
-      try {
-        const { url } = await uploadFile(file);
+  const insertUploadPlaceholder = useCallback(
+    (file: File) => {
+      const uploadId = generateUploadId();
+      registerPendingUpload(uploadId, file);
 
-        let attachmentType: AttachmentType = "FILE";
-        if (file.type.startsWith("image/")) {
-          attachmentType = "IMAGE";
-        } else if (file.type.startsWith("video/")) {
-          attachmentType = "VIDEO";
+      editor.update(() => {
+        const selection = $getSelection();
+        if ($isRangeSelection(selection)) {
+          const placeholderNode = $createUploadPlaceholderNode({
+            uploadId,
+            filename: file.name,
+            fileSize: file.size,
+            mimeType: file.type,
+          });
+          selection.insertNodes([placeholderNode, $createParagraphNode()]);
         }
-
-        editor.update(() => {
-          const selection = $getSelection();
-          if ($isRangeSelection(selection)) {
-            const attachmentNode = $createAttachmentNode({
-              attachmentType,
-              url,
-              filename: file.name,
-              mimeType: file.type,
-              size: file.size,
-            });
-            selection.insertNodes([attachmentNode, $createParagraphNode()]);
-          }
-        });
-      } catch (error) {
-        console.error("Upload failed:", error);
-        alert(`Upload failed: ${error instanceof Error ? error.message : "Unknown error"}`);
-      }
+      });
     },
-    [editor, uploadFile]
+    [editor]
   );
 
   const executeCommand = useCallback(
@@ -200,12 +190,12 @@ export function SlashCommandPlugin({ anchorElem }: SlashCommandPluginProps) {
           case "quote":
             $setBlocksType(selection, () => $createQuoteNode());
             break;
-          case "image":
+          case "media":
           case "file":
             pendingCommandRef.current = command;
             setTimeout(() => {
               if (fileInputRef.current) {
-                fileInputRef.current.accept = command === "image" ? "image/*,video/*" : "*/*";
+                fileInputRef.current.accept = command === "media" ? "image/*,video/*" : "*/*";
                 fileInputRef.current.click();
               }
             }, 0);
@@ -371,7 +361,7 @@ export function SlashCommandPlugin({ anchorElem }: SlashCommandPluginProps) {
         onChange={(e) => {
           const file = e.target.files?.[0];
           if (file) {
-            handleFileUpload(file);
+            insertUploadPlaceholder(file);
           }
           e.target.value = "";
           pendingCommandRef.current = null;
@@ -389,7 +379,7 @@ export function SlashCommandPlugin({ anchorElem }: SlashCommandPluginProps) {
           {filteredCommands.map((option, index) => {
             const prevOption = filteredCommands[index - 1];
             const showDivider = prevOption && prevOption.section === "media" && option.section === "blocks";
-            
+
             return (
               <div key={option.command}>
                 {showDivider && <div className="my-1 h-px bg-border" />}

--- a/src/lib/hooks/use-upload.ts
+++ b/src/lib/hooks/use-upload.ts
@@ -8,6 +8,11 @@ interface UploadResult {
   url: string;
 }
 
+interface UploadOptions {
+  onProgress?: (progress: number) => void; // 0-100
+  signal?: AbortSignal;
+}
+
 function sanitizeFilename(filename: string): string {
   return filename.replace(/[^a-zA-Z0-9.-]/g, "_");
 }
@@ -28,6 +33,8 @@ function buildBlobPathname(
  * Hook that provides a unified file upload function.
  * Automatically uses the correct storage provider (R2 or Vercel Blob)
  * based on server configuration.
+ *
+ * Supports progress tracking via onProgress callback and cancellation via AbortSignal.
  */
 export function useUpload() {
   const { data: storageInfo } = api.upload.storageInfo.useQuery(undefined, {
@@ -38,8 +45,16 @@ export function useUpload() {
   const getUploadUrl = api.upload.getUploadUrl.useMutation();
 
   const uploadFile = useCallback(
-    async (file: File): Promise<UploadResult> => {
+    async (file: File, options?: UploadOptions): Promise<UploadResult> => {
+      const { onProgress, signal } = options ?? {};
       const provider = storageInfo?.provider ?? "r2";
+
+      // Check if already cancelled
+      if (signal?.aborted) {
+        throw new DOMException("Upload cancelled", "AbortError");
+      }
+
+      onProgress?.(0);
 
       if (provider === "vercel-blob") {
         const pathname = buildBlobPathname(
@@ -51,8 +66,12 @@ export function useUpload() {
           access: "public",
           handleUploadUrl: "/api/upload/blob",
         });
+        onProgress?.(100);
         return { url: blob.url };
       }
+
+      // R2 upload with progress tracking
+      onProgress?.(2);
 
       const { uploadUrl, publicUrl } = await getUploadUrl.mutateAsync({
         filename: file.name,
@@ -60,16 +79,47 @@ export function useUpload() {
         size: file.size,
       });
 
-      const uploadResponse = await fetch(uploadUrl, {
-        method: "PUT",
-        body: file,
-        headers: { "Content-Type": file.type },
-      });
-
-      if (!uploadResponse.ok) {
-        throw new Error(`Upload failed: ${uploadResponse.status}`);
+      if (signal?.aborted) {
+        throw new DOMException("Upload cancelled", "AbortError");
       }
 
+      onProgress?.(5);
+
+      // Use XMLHttpRequest for upload progress tracking
+      await new Promise<void>((resolve, reject) => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("PUT", uploadUrl);
+        xhr.setRequestHeader("Content-Type", file.type);
+
+        // Handle cancellation
+        if (signal) {
+          signal.addEventListener("abort", () => xhr.abort(), { once: true });
+        }
+
+        xhr.upload.onprogress = (e) => {
+          if (e.lengthComputable) {
+            // Map upload progress to 5-98% range (5% for presigned URL, 98-100% for finalization)
+            const uploadPercent = 5 + (e.loaded / e.total) * 93;
+            onProgress?.(Math.round(uploadPercent));
+          }
+        };
+
+        xhr.onload = () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve();
+          } else {
+            reject(new Error(`Upload failed: ${xhr.status}`));
+          }
+        };
+
+        xhr.onerror = () => reject(new Error("Upload failed"));
+        xhr.onabort = () =>
+          reject(new DOMException("Upload cancelled", "AbortError"));
+
+        xhr.send(file);
+      });
+
+      onProgress?.(100);
       return { url: publicUrl };
     },
     [storageInfo?.provider, storageInfo?.userId, storageInfo?.blobPathPrefix, getUploadUrl]

--- a/src/lib/upload-store.ts
+++ b/src/lib/upload-store.ts
@@ -1,0 +1,50 @@
+/**
+ * Simple module-level registry for passing File objects to UploadPlaceholderNodes.
+ *
+ * When a plugin initiates an upload, it:
+ * 1. Generates an upload ID
+ * 2. Registers the File here with an AbortController
+ * 3. Inserts an UploadPlaceholderNode with that ID
+ *
+ * The placeholder component retrieves the File, performs the upload,
+ * and cleans up the entry when done.
+ */
+
+interface PendingUploadEntry {
+  file: File;
+  abortController: AbortController;
+}
+
+const pendingUploads = new Map<string, PendingUploadEntry>();
+
+let nextId = 0;
+
+export function generateUploadId(): string {
+  return `upload-${Date.now()}-${nextId++}`;
+}
+
+export function registerPendingUpload(id: string, file: File): AbortController {
+  const abortController = new AbortController();
+  pendingUploads.set(id, { file, abortController });
+  return abortController;
+}
+
+export function getPendingUpload(id: string): PendingUploadEntry | undefined {
+  return pendingUploads.get(id);
+}
+
+export function removePendingUpload(id: string): void {
+  const entry = pendingUploads.get(id);
+  if (entry && !entry.abortController.signal.aborted) {
+    entry.abortController.abort();
+  }
+  pendingUploads.delete(id);
+}
+
+export function cancelPendingUpload(id: string): void {
+  const entry = pendingUploads.get(id);
+  if (entry) {
+    entry.abortController.abort();
+  }
+  pendingUploads.delete(id);
+}


### PR DESCRIPTION
## Summary

- **Upload placeholders redesigned**: Full-width, borderless, aspect-ratio-aware placeholders that match the final rendered media/file layouts. File upload placeholders mirror the finished file attachment lockup (same icon, padding, text sizes). Media placeholders use a centered vertical layout with media type icon and short progress bar.
- **Video freeze-frame thumbnails**: Captures the first video frame via canvas during upload and passes it as thumbnailUrl, so uploaded videos show an instant preview instead of loading from the network.
- **Full-width media in editor**: Images and videos render at full container width instead of inline-block, eliminating the brief size jump when placeholders are replaced with final media.
- **Aspect-ratio-aware loading states**: AttachmentNode loading spinner uses actual media dimensions (passed from the upload) instead of a fixed h-48 height, and skips the loading state entirely when a thumbnail is already available.
- **Draft restoration fix**: Fixed a critical bug where Next.js page caching (offscreen/Activity) caused stale draft content to appear or overwrite the DB when navigating back to a draft. Replaced fragile ref-based state tracking with a mountId pattern that resets on every page reappear. Also flushes pending autosaves on unmount so edits are never lost.
- **Floating (+) button positioning**: Added ResizeObserver and MutationObserver so the add button repositions when decorator nodes change size (e.g. when a placeholder aspect ratio loads asynchronously).
- **Rename Image to Media** in slash commands and floating add button to reflect support for both images and videos.
- **Upload progress and cancellation**: Placeholder blocks show filename, size, progress bar, and percentage. Cancel button uses the same hover-reveal style as finished media delete button.

## Test plan

- [x] Upload an image -- placeholder shows at correct aspect ratio, transitions smoothly to final media
- [x] Upload a video -- placeholder shows video icon and aspect ratio, final media shows freeze-frame thumbnail with play button
- [x] Upload a non-media file -- placeholder matches finished file attachment layout with progress bar on the right
- [x] Cancel an upload mid-progress via the X button
- [x] Create a new draft, type content, wait for Draft saved, navigate to home, reopen from dropdown -- content should be restored
- [x] Edit a restored draft, navigate away and back -- latest content should appear, not stale content
- [x] Verify the (+) button stays correctly positioned during and after media uploads

Generated with [Claude Code](https://claude.com/claude-code)