### PR TITLE
Add missing onError handlers for post mutations

### DIFF
--- a/src/app/(main)/compose/page.tsx
+++ b/src/app/(main)/compose/page.tsx
@@ -130,6 +130,10 @@ export default function ComposePage() {
       utils.draft.list.invalidate();
       router.push(`/post/${post.id}`);
     },
+    onError: (err) => {
+      console.error("[Draftboard] Failed to publish post:", err);
+      alert(`Failed to publish: ${err.message}`);
+    },
   });
 
   // Debounced autosave effect

--- a/src/app/(main)/post/[id]/edit/page.tsx
+++ b/src/app/(main)/post/[id]/edit/page.tsx
@@ -51,6 +51,10 @@ export default function EditPostPage({ params }: EditPostPageProps) {
       utils.post.byProject.invalidate();
       router.push(`/post/${updatedPost.id}`);
     },
+    onError: (err) => {
+      console.error("[Draftboard] Failed to save post:", err);
+      alert(`Failed to save changes: ${err.message}`);
+    },
   });
 
   const handleEditorChange = useCallback((data: PostEditorData) => {


### PR DESCRIPTION
## Summary
- Add `onError` handler to `post.update` mutation on the edit page
- Add `onError` handler to `post.create` mutation on the compose page
- Both mutations were silently swallowing errors — clicking "Save Changes" or "Publish" did nothing on failure with no feedback to the user

## Test plan
- [ ] Edit a post and trigger a save error (e.g. disconnect network) — verify alert appears
- [ ] On compose page, trigger a publish error — verify alert appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)